### PR TITLE
Improve swipe to previous/next UX, v0.8.4

### DIFF
--- a/photo_objects/django/static/photo_objects/global.css
+++ b/photo_objects/django/static/photo_objects/global.css
@@ -720,8 +720,8 @@ div.photo.surface {
   position: relative;
 }
 
-div.photo.surface.previous:after,
-div.photo.surface.next:after {
+div.photo.surface.previous:before,
+div.photo.surface.next:before {
   content: "←";
   position: absolute;
   left: 1rem;
@@ -734,7 +734,7 @@ div.photo.surface.next:after {
   font-weight: 600;
 }
 
-div.photo.surface.next:after {
+div.photo.surface.next:before {
   content: "→";
   left: unset;
   right: 1rem;

--- a/photo_objects/django/templates/photo_objects/photo/show.html
+++ b/photo_objects/django/templates/photo_objects/photo/show.html
@@ -33,7 +33,8 @@
     }
   });
 
-  addEventListener("DOMContentLoaded", function () {
+  // Wait for load event instead of DOMContentLoaded so that images and styles have been loaded before configuring the event listeners.
+  addEventListener("load", function () {
     const photo = document.querySelector('.photo img');
     const surface = document.querySelector('.photo.surface');
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "photo-objects"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
     "markdown~=3.7",
     "minio~=7.2",


### PR DESCRIPTION
Wait for `load` instead of `DOMContentLoaded` to ensure image size is known when configuring the trigger distance. Use before element for trigger feedback to ensure it is not displayed over the photo.