### PR TITLE
Block access to photos in admin albums, v0.11.2

### DIFF
--- a/photo_objects/django/api/auth.py
+++ b/photo_objects/django/api/auth.py
@@ -12,28 +12,32 @@ from photo_objects.django.api.utils import (
 )
 
 
-def check_album_access(request: HttpRequest, album_key: str):
+def _check_album_access(request: HttpRequest, album: Album) -> Album:
+    if not request.user.is_authenticated:
+        if album.visibility == Album.Visibility.PRIVATE:
+            raise AlbumNotFound(album.key)
+
+    if not request.user.is_staff:
+        if album.visibility == Album.Visibility.ADMIN:
+            raise AlbumNotFound(album.key)
+
+    return album
+
+
+def check_album_access(request: HttpRequest, album_key: str) -> Album:
     try:
         album = Album.objects.get(key=album_key)
     except Album.DoesNotExist:
         raise AlbumNotFound(album_key) from None
 
-    if not request.user.is_authenticated:
-        if album.visibility == Album.Visibility.PRIVATE:
-            raise AlbumNotFound(album_key)
-
-    if not request.user.is_staff:
-        if album.visibility == Album.Visibility.ADMIN:
-            raise AlbumNotFound(album_key)
-
-    return album
+    return _check_album_access(request, album)
 
 
 def check_photo_access(
         request: HttpRequest,
         album_key: str,
         photo_key: str,
-        size_key: str):
+        size_key: str) -> Photo:
     try:
         size = PhotoSize(size_key)
     except ValueError:
@@ -44,9 +48,9 @@ def check_photo_access(
     except Photo.DoesNotExist:
         raise PhotoNotFound(album_key, photo_key) from None
 
+    _check_album_access(request, photo.album)
+
     if not request.user.is_authenticated:
-        if photo.album.visibility == Album.Visibility.PRIVATE:
-            raise AlbumNotFound(album_key)
         if size == PhotoSize.ORIGINAL:
             raise Unauthorized()
 

--- a/photo_objects/django/signals.py
+++ b/photo_objects/django/signals.py
@@ -44,8 +44,13 @@ def update_album_on_photo_delete(sender, **kwargs):
         album.save()
         return
 
+    try:
+        cover_photo = album.cover_photo
+    except Photo.DoesNotExist:
+        cover_photo = None
+
     needs_save = False
-    if album.cover_photo is None:
+    if cover_photo is None:
         needs_save = True
         album.cover_photo = first_photo
 

--- a/photo_objects/django/tests/test_auth.py
+++ b/photo_objects/django/tests/test_auth.py
@@ -13,7 +13,13 @@ class AuthViewTests(TestCase):
     @classmethod
     def setUpTestData(cls):
         user = get_user_model()
-        user.objects.create_user(username='test-auth', password='test')
+        user.objects.create_user(
+            username='test-auth-user',
+            password='test')
+        user.objects.create_user(
+            username='test-auth-admin',
+            password='test',
+            is_staff=True)
 
         public_album = Album.objects.create(
             key="test-auth-public", visibility=Album.Visibility.PUBLIC)
@@ -69,17 +75,41 @@ class AuthViewTests(TestCase):
             [self.private_path('sm'), 403],
             [self.private_path('lg'), 403],
             [self.private_path('og'), 403],
-            [self.admin_path('sm'), 204],
-            [self.admin_path('lg'), 204],
+            [self.admin_path('sm'), 403],
+            [self.admin_path('lg'), 403],
             [self.admin_path('og'), 403],
             [self.not_found_path('sm'), 403],
             [self.not_found_path('lg'), 403],
             [self.not_found_path('og'), 403],
         ])
 
-    def test_authenticated_user_can_access_all_photos(self):
+    def test_authenticated_user_access(self):
         login_success = self.client.login(
-            username='test-auth', password='test')
+            username='test-auth-user', password='test')
+        self.assertTrue(login_success)
+
+        self._test_access([
+            [self.public_path('asd'), 403],
+            [self.public_path('sm'), 204],
+            [self.public_path('lg'), 204],
+            [self.public_path('og'), 204],
+            [self.hidden_path('sm'), 204],
+            [self.hidden_path('lg'), 204],
+            [self.hidden_path('og'), 204],
+            [self.private_path('sm'), 204],
+            [self.private_path('lg'), 204],
+            [self.private_path('og'), 204],
+            [self.admin_path('sm'), 403],
+            [self.admin_path('lg'), 403],
+            [self.admin_path('og'), 403],
+            [self.not_found_path('sm'), 403],
+            [self.not_found_path('lg'), 403],
+            [self.not_found_path('og'), 403],
+        ])
+
+    def test_admin_user_access(self):
+        login_success = self.client.login(
+            username='test-auth-admin', password='test')
         self.assertTrue(login_success)
 
         self._test_access([

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "photo-objects"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
     "ciou>=0.7.0,<1.0.0",
     "markdown~=3.7",


### PR DESCRIPTION
Non-admin users should not be able to see photos in albums with admin visibility anymore. The photos were previously visible for everyone, because special albums with admin visibility were used to configure social media previews. 